### PR TITLE
fix: Align response of validate player endpoint with expected format/content

### DIFF
--- a/API/requests/ValidatePlayer.js
+++ b/API/requests/ValidatePlayer.js
@@ -1,12 +1,19 @@
 module.exports = function(req, res, next) {
     var header = {"asof":req.currentTime,"pid":req.profileid || null};
+    var result;
     if(req.session_valid) {
-        if(req.profile.uniquenick != req.queryParams.SoldierNick || req.profileid != req.queryParams.pid) {
-            req.session_valid = false;
+        if(req.profile.uniquenick != req.queryParams.SoldierNick) {
+            result = "InvalidReportedNick";
+        } else if(req.profileid != req.queryParams.pid) {
+            result = "InvalidReportedProfileID";
+        } else {
+            result = "Ok";
+            header["nick"] = req.profile.uniquenick;
         }
-        header["nick"] = req.profile.uniquenick;
+    } else {
+        result = "InvalidAuthProfileID";
     }
             
-    var send_entries = [[header], [{"result": req.session_valid ? "OK" : "NAK"}]];
+    var send_entries = [[header], [{"result": result}]];
     req.sendResponse(res, send_entries);
 };

--- a/API/requests/ValidatePlayer.js
+++ b/API/requests/ValidatePlayer.js
@@ -1,16 +1,29 @@
 module.exports = function(req, res, next) {
-    var header = {"asof":req.currentTime,"pid":req.profileid || null};
+    var header = {
+        "pid": null, // actual pid from session
+        "nick": null, // actual nick from session
+        "spid": req.queryParams.pid, // pid as passed in request
+        "asof": req.currentTime
+    };
+
     var result;
     if(req.session_valid) {
+        header["pid"] = req.profileid;
+        header["nick"] = req.profile.uniquenick;
         if(req.profile.uniquenick != req.queryParams.SoldierNick) {
             result = "InvalidReportedNick";
         } else if(req.profileid != req.queryParams.pid) {
             result = "InvalidReportedProfileID";
         } else {
             result = "Ok";
-            header["nick"] = req.profile.uniquenick;
         }
     } else {
+        // `pid` and/or `nick` need to differ from request in order to cause a kick/ban
+        header["pid"] = 0;
+        // `[prefix] nick` usually get cut off after 23 characters in the game's client-server protocols
+        // While the limit appears to not be applied to values returned by the validation,
+        // it's probably best to follow that convention/limit
+        header["nick"] = ("INVALID " + req.queryParams.SoldierNick).slice(0, 23)
         result = "InvalidAuthProfileID";
     }
             


### PR DESCRIPTION
According to my research and my discussions with [art567](https://github.com/art567), the response would provide match the following example. Assuming a player with `nick=a` and `pid=1` is trying to spoof a player with `nick=b` and `pid=2`, the behavior would be (assuming auth token is valid):
```
GET ValidatePlayer?pid=2&SoldierNick=b&auth={tokenFor(pid=1+nick=a)}

HTTP/1.1 200 OK
O
H pid nick spid asof
D 1 a 2 1717778141
H result
D InvalidReportedProfileID
$ 63 $
```
_Note:_ The length indicator is incorrect.

During my testing (using a BF2 server, which should work the exact same as the validation was "backported" from 2142 to BF2), the server only issued a kick/ban if a) `pid != spid` in the response or b) `nick != SoldierNick`. The `result` codes don't get passed to the Python host, which handles the response in this callback. Which is probably why even returning `Ok` will lead to a ban if the values don't match.

```python
# This is how long we will ban a mis-validated player for, in seconds.
BANTIME = 7 * 24 * 60 * 60

# onPlayerNameValidated is called by the engine when a reply from GameSpy arives, this is done directly when the player connects to the game server.
def onPlayerNameValidated(realNick, oldNick, realPID, oldPID, player):
	if realNick != oldNick:
		message = "Player: %s, real name %s, was kicked and banned for using Name Hacks" % (oldNick, realNick)
	elif realPID != oldPID:
		message = "Player: %s tried to use wrong PlayerID %d (real PID %d); kicked and banned for using PID Hacks" % (oldNick, oldPID, realPID)
	else:
		return
	host.rcon_invoke("admin.banPlayer %d %d" % (player.index, BANTIME))
	host.sgl_sendTextMessage(0, 12, 1, message, 0)
```

The values passed to the callback:
| Name | Referenced value |
|----------|-------------------------|
| `realNick` | `nick` (response) |
| `oldNick` | `SoldierNick` (request) |
| `realPID` | `pid` (response) |
| `oldPID` | `spid` (response) |